### PR TITLE
Update to allow to work on versions of Mac OS X with SIP

### DIFF
--- a/pybonjour.py
+++ b/pybonjour.py
@@ -88,7 +88,7 @@ if sys.platform == 'win32':
     _CFunc = ctypes.WINFUNCTYPE
 else:
     if sys.platform == 'darwin':
-        _libdnssd = 'libSystem.B.dylib'
+        _libdnssd = '/usr/lib/libSystem.B.dylib'
     else:
         _libdnssd = 'libdns_sd.so.1'
 


### PR DESCRIPTION
The System Integrity Protection feature on more recent versions of Mac OS X prevents the library libSystem.B.dylib being dlopened unless its exact path is specified. This fix allows pybonjour to install on 10.12.6 Sierra.